### PR TITLE
Add missing PrimaryCaregiver and FamilyHead

### DIFF
--- a/opensrp-chw-core/src/main/java/org/smartregister/chw/core/activity/CoreFamilyProfileActivity.java
+++ b/opensrp-chw-core/src/main/java/org/smartregister/chw/core/activity/CoreFamilyProfileActivity.java
@@ -357,6 +357,8 @@ public abstract class CoreFamilyProfileActivity extends BaseFamilyProfileActivit
 
     public void goToAncProfileActivity(CommonPersonObjectClient patient, Bundle bundle) {
         patient.getColumnmaps().putAll(getAncCommonPersonObject(patient.entityId()).getColumnmaps());
+        patient.getColumnmaps().put(org.smartregister.family.util.Constants.INTENT_KEY.FAMILY_HEAD, getFamilyHead());
+        patient.getColumnmaps().put(org.smartregister.family.util.Constants.INTENT_KEY.PRIMARY_CAREGIVER, getPrimaryCaregiver());
         startActivity(initProfileActivityIntent(patient, bundle, getAncMemberProfileActivityClass()));
     }
 


### PR DESCRIPTION
This is required when calling **goToAncActivity** from FamilyProfile (to load the ANC member profile). 
The missing data was resulting in the ANC profile loading without those title texts.  