### PR TITLE
Show insurance and rhc card details when editing child U5

### DIFF
--- a/opensrp-chw/build.gradle
+++ b/opensrp-chw/build.gradle
@@ -234,7 +234,7 @@ android {
 
 dependencies {
 
-    implementation('org.smartregister:opensrp-client-chw-core:1.0.30-SNAPSHOT@aar') {
+    implementation('org.smartregister:opensrp-client-chw-core:1.0.31-SNAPSHOT@aar') {
         transitive = true
     }
     implementation 'com.android.support:appcompat-v7:28.0.0'

--- a/opensrp-chw/build.gradle
+++ b/opensrp-chw/build.gradle
@@ -234,7 +234,7 @@ android {
 
 dependencies {
 
-    implementation('org.smartregister:opensrp-client-chw-core:1.0.31-SNAPSHOT@aar') {
+    implementation('org.smartregister:opensrp-client-chw-core:1.0.32-SNAPSHOT@aar') {
         transitive = true
     }
     implementation 'com.android.support:appcompat-v7:28.0.0'


### PR DESCRIPTION
- Update chw-core snapshot dependency version and point to version with changes in core to retrieve missing details for showing when editing child U5
- Changes in **chw-core** introduced in https://github.com/OpenSRP/opensrp-client-chw-core/pull/59
----
See https://github.com/OpenSRP/opensrp-client-chw/issues/625 for details 