### PR TITLE
Fix family services and medical history rows

### DIFF
--- a/opensrp-chw/build.gradle
+++ b/opensrp-chw/build.gradle
@@ -233,7 +233,7 @@ android {
 }
 
 dependencies {
-    implementation('org.smartregister:opensrp-client-chw-core:1.1.18-SNAPSHOT@aar') {
+    implementation('org.smartregister:opensrp-client-chw-core:1.1.19-SNAPSHOT@aar') {
         transitive = true
     }
     implementation 'androidx.appcompat:appcompat:1.0.0'

--- a/opensrp-chw/src/main/java/org/smartregister/chw/activity/FamilyPlanningMemberProfileActivity.java
+++ b/opensrp-chw/src/main/java/org/smartregister/chw/activity/FamilyPlanningMemberProfileActivity.java
@@ -98,7 +98,7 @@ public class FamilyPlanningMemberProfileActivity extends CoreFamilyPlanningMembe
                 IndividualProfileRemoveActivity.startIndividualProfileActivity(FamilyPlanningMemberProfileActivity.this,
                         getClientDetailsByBaseEntityID(fpMemberObject.getBaseEntityId()),
                         fpMemberObject.getFamilyBaseEntityId(), fpMemberObject.getFamilyHead(),
-                        fpMemberObject.getPrimaryCareGiver(), MalariaRegisterActivity.class.getCanonicalName());
+                        fpMemberObject.getPrimaryCareGiver(), FpRegisterActivity.class.getCanonicalName());
                 return true;
             case R.id.action_fp_change:
                 FpRegisterActivity.startFpRegistrationActivity(this, fpMemberObject.getBaseEntityId(), fpMemberObject.getAge(), CoreConstants.JSON_FORM.getFpChengeMethodForm(), FamilyPlanningConstants.ActivityPayload.CHANGE_METHOD_PAYLOAD_TYPE);
@@ -200,19 +200,19 @@ public class FamilyPlanningMemberProfileActivity extends CoreFamilyPlanningMembe
 
     @Override
     public void setProfileName(String s) {
-        TextView textView = findViewById(org.smartregister.malaria.R.id.textview_name);
+        TextView textView = findViewById(org.smartregister.fp.R.id.textview_name);
         textView.setText(s);
     }
 
     @Override
     public void setProfileDetailOne(String s) {
-        TextView textView = findViewById(org.smartregister.malaria.R.id.textview_gender);
+        TextView textView = findViewById(org.smartregister.fp.R.id.textview_gender);
         textView.setText(s);
     }
 
     @Override
     public void setProfileDetailTwo(String s) {
-        TextView textView = findViewById(org.smartregister.malaria.R.id.textview_address);
+        TextView textView = findViewById(org.smartregister.fp.R.id.textview_address);
         textView.setText(s);
     }
 

--- a/opensrp-chw/src/main/java/org/smartregister/chw/interactor/FamilyPlanningProfileInteractor.java
+++ b/opensrp-chw/src/main/java/org/smartregister/chw/interactor/FamilyPlanningProfileInteractor.java
@@ -38,15 +38,14 @@ public class FamilyPlanningProfileInteractor extends CoreFamilyPlanningProfileIn
         Runnable runnable = new Runnable() {
 
             Date lastVisitDate = getLastVisitDate(memberObject); // CoreFamilyPlanningProfileInteractor#getLastVisitDate
-            AlertStatus familyAlert = FamilyDao.getFamilyAlertStatus(memberObject.getBaseEntityId());
+            AlertStatus familyAlert = FamilyDao.getFamilyAlertStatus(memberObject.getFamilyBaseEntityId());
             Alert upcomingService = getAlerts(context, memberObject.getBaseEntityId());
 
             @Override
             public void run() {
                 appExecutors.mainThread().execute(() -> {
-                    callback.refreshLastVisit(lastVisitDate);
                     callback.refreshFamilyStatus(familyAlert);
-                    callback.refreshMedicalHistory(VisitDao.memberHasNonFamilyPlanningVisits(memberObject.getBaseEntityId()));
+                    callback.refreshMedicalHistory(lastVisitDate);
                     if (upcomingService == null) {
                         callback.refreshUpComingServicesStatus("", AlertStatus.complete, new Date());
                     } else {


### PR DESCRIPTION
- Refactor hasMedicalHistory to use lastVisitDate as the determinant
- Use the family baseEntityId to get the family alert status