### PR TITLE
Update wcaro Togo to v1.2.6 

### DIFF
--- a/opensrp-chw/build.gradle
+++ b/opensrp-chw/build.gradle
@@ -293,8 +293,8 @@ android {
         togo {
             dimension = 'baseDimension'
             applicationIdSuffix ".togo"
-            versionCode 23
-            versionName "1.2.5"
+            versionCode 24
+            versionName "1.2.6"
             buildConfigField "int", "OPENMRS_UNIQUE_ID_INITIAL_BATCH_SIZE", '1000'
             buildConfigField "int", "OPENMRS_UNIQUE_ID_BATCH_SIZE", '500'
             buildConfigField "String", 'opensrp_url', '"https://wcaro-tg.smartregister.org/opensrp/"'
@@ -305,6 +305,8 @@ android {
             buildConfigField "String[]", "ALLOWED_LOCATION_LEVELS", '{"National", "Regional" , "District" , "Formation sanitaire", "Supervisor", "Village"}'
             buildConfigField "String", 'DEFAULT_LOCATION_DEBUG', '"Village"'
             buildConfigField "String", 'DEFAULT_LOCATION', '"Village"'
+            buildConfigField "int", "MAX_CONNECTION_TIMEOUT", '5'
+            buildConfigField "int", "MAX_READ_TIMEOUT", '5'
             buildConfigField "int", "DATABASE_VERSION", '20'
         }
         liberia {

--- a/opensrp-chw/src/main/java/org/smartregister/chw/sync/ChwSyncIntentService.java
+++ b/opensrp-chw/src/main/java/org/smartregister/chw/sync/ChwSyncIntentService.java
@@ -25,6 +25,6 @@ public class ChwSyncIntentService extends SyncIntentService {
 
     @Override
     protected Integer getEventBatchSize(){
-        return 250;
-    }
+        return 180;
+    } // Should this be configurable?
 }


### PR DESCRIPTION
- Added connection timeouts
- Reduced the event batch size to 180 to try and reduce the number of events being synced to the server 