### PR TITLE
Fix Job Aids view crashing in CHW

### DIFF
--- a/opensrp-chw/build.gradle
+++ b/opensrp-chw/build.gradle
@@ -382,6 +382,8 @@ dependencies {
     //For viewing PDFs in the app
     implementation 'com.github.barteksc:android-pdf-viewer:3.2.0-beta.1'
 
+    implementation 'com.github.lecho:hellocharts-android:v1.5.8@aar'
+
     testImplementation "org.koin:koin-test:2.0.1"
     testImplementation 'junit:junit:4.13'
     testImplementation 'org.mockito:mockito-core:3.1.0'


### PR DESCRIPTION
- Added the missing charts library removed in this [PR](https://github.com/opensrp/opensrp-client-chw/pull/1867)

----
This fixes https://github.com/opensrp/opensrp-client-chw/issues/1925